### PR TITLE
corrected chmod bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2023-0613
+
+### Changed
+- Fixed a bug that causes Scaffolder to fail if certain directories or files may not exist within a given template.
+
 ## [1.1.0] - 2023-06-07
 
-## Changed
+### Changed
 - Template tokens replacement have been updated to accommodate new templates:
   
   | Old Token         | New Token         |

--- a/README.md
+++ b/README.md
@@ -29,14 +29,14 @@ scaffolder init -m <module-name> -b <bin-name> [-t <template-url>] [-d <descript
 
 #
 
-| Flag                | Required | DescriptionKey                                                                                      |
-|---------------------|----------|-----------------------------------------------------------------------------------------------------|
-| `-m, --module-name` | Yes      | The name of the Go module (e.g., github.com/username/project-name) as set in the `go.mod` file.     |
-| `-b, --bin-name`    | Yes      | The name of the binary file to be compiled. It sets the service name in the `conf.go` file.         |
+| Flag                | Required | DescriptionKey                                                                                                                                 |
+|---------------------|----------|------------------------------------------------------------------------------------------------------------------------------------------------|
+| `-m, --module-name` | Yes      | The name of the Go module (e.g., github.com/username/project-name) as set in the `go.mod` file.                                                |
+| `-b, --bin-name`    | Yes      | The name of the binary file to be compiled. It sets the service name in the `conf.go` file.                                                    |
 | `-t, --template`    | No       | The URL of the GitHub repository to clone and use as a template. Defaults to [go-basic-tmpl](https://github.com/twistingmercury/go-basic-tmpl) |
-| `-d, --description` | No       | A brief description of the project, set in the Dockerfile as a label.                               |
-| `-v, --vendor-name` | No       | The name of the vendor, set in the Dockerfile as a label.                                           |
-| `-h, --help`        | No       | Display help information for the `init` command.                                                    |
+| `-d, --description` | No       | A brief description of the project, set in the Dockerfile as a label.                                                                          |
+| `-v, --vendor-name` | No       | The name of the vendor, set in the Dockerfile as a label.                                                                                      |
+| `-h, --help`        | No       | Display help information for the `init` command.                                                                                               |
 
 ### Example
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -232,5 +232,9 @@ func GoModTidy(path string) error {
 
 // MakeExecutable makes a file executable.
 func MakeExecutable(path string) error {
+	info, err := os.Stat(path)
+	if os.IsNotExist(err) || info.IsDir() {
+		return nil
+	}
 	return os.Chmod(path, 0755)
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -7,11 +7,9 @@ import (
 )
 
 const logo = `
- o-o            o-o o-o    o    o         
-|               |   |      |    |         
- o-o   o-o  oo -O- -O- o-o |  o-O o-o o-o 
-    | |    | |  |   |  | | | |  | |-' |   
-o--o   o-o o-o- o   o  o-o o  o-o o-o o `
+╔═╗┌─┐┌─┐┌─┐┌─┐┌─┐┬  ┌┬┐┌─┐┬─┐
+╚═╗│  ├─┤├┤ ├┤ │ ││   ││├┤ ├┬┘
+╚═╝└─┘┴ ┴└  └  └─┘┴─┘─┴┘└─┘┴└─`
 
 func NewVersionCmd() *cobra.Command {
 	return &cobra.Command{
@@ -19,10 +17,9 @@ func NewVersionCmd() *cobra.Command {
 		Short: "Returns the current scaffolder version",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			_, err := fmt.Fprintf(cmd.OutOrStdout(),
-				"%s\nversion: %s, commit date: %s\n\n",
+				"%s\n%s\n\n",
 				logo,
-				conf.BuildVersion(),
-				conf.BuildDate())
+				conf.BuildVersion)
 			return err
 		},
 	}

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -1,15 +1,6 @@
 package conf
 
-const (
-	// build information: this is set at compile time using LDFlags
-	buildVer  = "v1.1.0"
-	buildDate = "2024-06-10"
+const ( // build information: this is set at compile time using LDFlags
+	BuildVersion = "v1.1.1"
+	CommitDate   = "2024-06-13"
 )
-
-func BuildVersion() string {
-	return buildVer
-}
-
-func BuildDate() string {
-	return buildDate
-}


### PR DESCRIPTION
## [1.1.1] - 2023-0613

### Changed
- Fixed a bug that causes Scaffolder to fail if certain directories or files may not exist within a given template.